### PR TITLE
Fixes snippet to latest ver on Maven repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Add this dependency to your project's POM:
 <dependency>
   <groupId>com.jwplayer</groupId>
   <artifactId>jwplatform</artifactId>
-  <version>0.4.0</version>
+  <version>0.3.1</version>
 </dependency>
 ```
 


### PR DESCRIPTION
Instead of 0.4.0, 0.3.1

At least, this is what I see, perhaps I am jumping to conclusions?
![image](https://user-images.githubusercontent.com/11856134/112019381-c28c3d00-8b05-11eb-8fc7-4c917b138f9a.png)
